### PR TITLE
バリデーションルール nullable の誤訳修正

### DIFF
--- a/translation-ja/validation.md
+++ b/translation-ja/validation.md
@@ -1270,7 +1270,7 @@ PHPの`filter_var`関数を使用する`filter`バリデータは、Laravelに�
 <a name="rule-nullable"></a>
 #### nullable
 
-フィールドは`null`であることをバリデートします。
+フィールドは`null`であることを許容します。
 
 <a name="rule-numeric"></a>
 #### numeric


### PR DESCRIPTION
原文の `may` を `must` と誤訳したものと思われる
> The field under validation may be null.