### PR TITLE
コマンドにスペースを追加

### DIFF
--- a/translation-ja/testing.md
+++ b/translation-ja/testing.md
@@ -52,7 +52,7 @@ Laravelには、アプリケーションのベース`TestCase`クラスに適用
 
 > {tip} [stubのリソース公開](/docs/{{version}}/artisan#stub-customization) を使って、Testスタブをカスタマイズできます。
 
-テストを生成したら、[PHPUnit](https://phpunit.de)を使用する場合と同様にテストメソッドを定義します。テストを実行するには、ターミナルから`vendor/bin/phpunit`または`phpartisantest`コマンドを実行します。
+テストを生成したら、[PHPUnit](https://phpunit.de)を使用する場合と同様にテストメソッドを定義します。テストを実行するには、ターミナルから`vendor/bin/phpunit`または`php artisan test`コマンドを実行します。
 
     <?php
 


### PR DESCRIPTION
`phpartisantest` を `php artisan test` に修正しました。

https://readouble.com/laravel/8.x/ja/testing.html

#21 と同様の修正です。
